### PR TITLE
Fix crash 2

### DIFF
--- a/src/DynamoCore/Configuration/Configurations.cs
+++ b/src/DynamoCore/Configuration/Configurations.cs
@@ -177,6 +177,7 @@ namespace Dynamo.Configuration
         internal static readonly double MaxCondensedPreviewHeight = 64.0;
         internal static readonly double DefCondensedContentWidth = 33.0;
         internal static readonly double DefCondensedContentHeight = 28.0;
+        internal static readonly string BusyString = ". . .";
 
         #endregion
 

--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -485,6 +485,17 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
+        /// Call this method only, when graph calculation is started.
+        /// CachedValue will be set to MirrorDataInProgress.
+        /// It's done in order to fix crash with preview bubble, when node hasn't been calculated,
+        /// but UI thread tried to get value.
+        /// </summary>
+        internal void SetCachedValueInProgress()
+        {
+            CachedValue = ProtoCore.MirrorDataInProgress.Instance;
+        }
+
+        /// <summary>
         /// This flag is used to determine if a node was involved in a recent execution.
         /// The primary purpose of this flag is to determine if the node's render packages 
         /// should be returned to client browser when it requests for them. This is mainly 

--- a/src/DynamoCore/Scheduler/DelegateBasedAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/DelegateBasedAsyncTask.cs
@@ -13,7 +13,7 @@ namespace Dynamo.Scheduler
 
         public override TaskPriority Priority
         {
-            get { return TaskPriority.Normal; }
+            get { return TaskPriority.BelowNormal; }
         }
 
         #region Public Class Operational Methods

--- a/src/DynamoCore/Scheduler/UpdateGraphAsyncTask.cs
+++ b/src/DynamoCore/Scheduler/UpdateGraphAsyncTask.cs
@@ -77,7 +77,10 @@ namespace Dynamo.Scheduler
                 {
                     var node = workspace.Nodes.FirstOrDefault(n => n.GUID.Equals(nodeGuid));
                     if (node != null)
+                    {
                         node.ClearDirtyFlag();
+                        node.SetCachedValueInProgress();
+                    }
                 }
 
                 return true;

--- a/src/Engine/ProtoCore/ProtoCore.csproj
+++ b/src/Engine/ProtoCore/ProtoCore.csproj
@@ -104,6 +104,7 @@
     <Compile Include="DSASM\HeapObjects.cs" />
     <Compile Include="Lang\InternalAttributes.cs" />
     <Compile Include="Lang\Replication\ArgumentAtLevel.cs" />
+    <Compile Include="Reflection\MirrorDataInProgress.cs" />
     <Compile Include="SyntaxAnalysis\AstVisitor.cs" />
     <Compile Include="AttributeEntry.cs" />
     <Compile Include="BuildStatus.cs" />

--- a/src/Engine/ProtoCore/Reflection/MirrorDataInProgress.cs
+++ b/src/Engine/ProtoCore/Reflection/MirrorDataInProgress.cs
@@ -1,0 +1,27 @@
+﻿using ProtoCore.DSASM;
+using ProtoCore.Mirror;
+
+namespace ProtoCore
+{
+    /// <summary>
+    /// WARNING: this class is used as temp value for CachedValue in NodeModel.
+    /// Don't try to get some value, in any case it will be something wrong.
+    /// </summary>
+    public class MirrorDataInProgress : MirrorData
+    {
+        private static MirrorDataInProgress instance;
+
+        public static MirrorDataInProgress Instance
+        {
+            get { return instance ?? (instance = new MirrorDataInProgress()); }
+
+        }
+
+        private MirrorDataInProgress()
+            : base(null, StackValue.BuildNull())
+        {
+            // Nothing here.
+        }
+
+    }
+}


### PR DESCRIPTION
### Purpose

NB! Fix is not working for Dynamo Revit. Crash is fixed, but you won't see ". . ." during computation.

Link to YouTrack:
[MAGN-9568](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9568) Crash in preview control
# Reason of crash:

In Dynamo there are several threads, let's call them UI and Core. When there is big calculation, UI thread tries to get some value from core, but this value has not been calculated yet.
Look next image.
Here we generate list 0..1000000. MirrorData is generated, but when we try to get value from svData (StackValue), it returns null.
![image](https://cloud.githubusercontent.com/assets/8158404/13455892/e0d12ca0-e068-11e5-9853-b8b9f9107920.png)
But if we wait for some time until calculation is done, we won't get any exception.
![image](https://cloud.githubusercontent.com/assets/8158404/13455965/390d3a62-e069-11e5-8526-edc8e22e523f.png)

After some investigation, it was found, that there are 3 async tasks: 
- `UpdateGraphAsyncTask` (engine calculates values)
- `QueryMirrorDataAsyncTask` (cached value of node is updated)
- `DelegateBasedAsyncTask` (update preview bubble)

When there is big calculation, these tasks are called in wrong order.

![image](https://cloud.githubusercontent.com/assets/8158404/13527255/818fa172-e216-11e5-87f4-9c27bbb36dc6.png)
![image](https://cloud.githubusercontent.com/assets/8158404/13527260/8a2f7ff0-e216-11e5-9299-875294b649e4.png)

You can easily see it in the next image.
![image](https://cloud.githubusercontent.com/assets/8158404/13527739/f55b38b6-e219-11e5-878e-869738bf3721.png)
# Fixes:
- Priority of `DelegateBasedAsyncTask` is reduced to `BelowNormal`.
- Created class-stub `MirrorDataInProgress`, instance of which is set during graph calculation.
- Created `busyTextBlock`, which is shown in preview bubble during big calculation.
### Declarations
- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
### Reviewers

@pbidenko , please take a look first.
